### PR TITLE
Speedup - loadMatrixBuffers

### DIFF
--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -1,6 +1,8 @@
 #ifndef _CIRCULARBUFFER_H_
 #define _CIRCULARBUFFER_H_
 
+// TODO: Consider INLINE for several functions - many small, only used in one place, in frequently used code
+
 /* Circular buffer object */
 typedef struct {
     int         size;   /* maximum number of elements           */

--- a/SmartMatrix.cpp
+++ b/SmartMatrix.cpp
@@ -24,6 +24,8 @@
 #include "SmartMatrix.h"
 #include "CircularBuffer.h"
 
+#define INLINE __attribute__( ( always_inline ) ) inline
+
 // these definitions may change if switching major display type
 #define MATRIX_ROW_PAIR_OFFSET      (MATRIX_HEIGHT/2)
 #define MATRIX_ROWS_PER_FRAME       (MATRIX_HEIGHT/2)
@@ -86,7 +88,7 @@ SmartMatrix::SmartMatrix() {
 
 }
 
-void SmartMatrix::matrixCalculations(void) {
+INLINE void SmartMatrix::matrixCalculations(void) {
     static unsigned char currentRow = 0;
 
     // only run the loop if there is free space, and fill the entire buffer before returning
@@ -121,7 +123,7 @@ void SmartMatrix::matrixCalculations(void) {
     }
 }
 
-void SmartMatrix::calculateTimerLut(void) {
+INLINE void SmartMatrix::calculateTimerLut(void) {
     int i;
 
     for (i = 0; i < LATCHES_PER_ROW; i++) {
@@ -344,7 +346,7 @@ void SmartMatrix::begin()
     FTM1_SC = FTM_SC_CLKS(1) | FTM_SC_PS(LATCH_TIMER_PRESCALE);
 }
 
-void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
+INLINE void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
 
     int i, j;
 


### PR DESCRIPTION
Zero all the pad and clk bits in parallel (rather than doing it bit by bit)

Use 2 MOVS instructions instead of 8 BFC instructions
Inside loop, so saves 192 instructions per row
(at 16 rows for a 32x32 panel, and 120 refresh per second this saves about 368,000 instructions per second)
should mean less overhead doing refreshes
