### PR TITLE
Fix examples to work with templates

### DIFF
--- a/SmartMatrix.h
+++ b/SmartMatrix.h
@@ -183,6 +183,7 @@ private:
 
 // single matrixUpdateBlocks buffer is divided up to hold matrixUpdateBlocks, addressLUT, timerLUT to simplify user sketch code and reduce constructor parameters
 #define SMARTMATRIX_ALLOCATE_BUFFERS(width, height, storage_depth, pwm_depth, rows) \
+    typedef RGB_TYPE(COLOR_DEPTH) SM_RGB; \
     static DMAMEM uint32_t matrixUpdateData[rows * width * (pwm_depth/3 / sizeof(uint32_t)) * 2]; \
     static DMAMEM uint8_t matrixUpdateBlocks[(sizeof(matrixUpdateBlock) * rows * pwm_depth/3) + (sizeof(addresspair) * height/2) + (sizeof(timerpair) * pwm_depth/3)]; \
     SmartMatrix<RGB_TYPE(storage_depth)> matrix(width, height, pwm_depth, rows, matrixUpdateData, matrixUpdateBlocks)

--- a/examples/Bitmaps/Bitmaps.ino
+++ b/examples/Bitmaps/Bitmaps.ino
@@ -18,18 +18,18 @@
 // chrome16 is a 16x16 pixel bitmap, exported from GIMP without modification
 #include "chrome16.c"
 
+#define COLOR_DEPTH 48
 const uint8_t kMatrixHeight = 32;       // known working: 16, 32
 const uint8_t kMatrixWidth = 32;        // known working: 32, 64
-const uint8_t kColorDepthRgb = 36;      // known working: 36, 48 (24 isn't efficient and has color correction issues)
 const uint8_t kDmaBufferRows = 4;       // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, kColorDepthRgb, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 int led = 13;
 
 void drawBitmap(int16_t x, int16_t y, const gimp32x32bitmap* bitmap) {
   for(unsigned int i=0; i < bitmap->height; i++) {
     for(unsigned int j=0; j < bitmap->width; j++) {
-      rgb24 pixel = { bitmap->pixel_data[(i*bitmap->width + j)*3 + 0],
+      SM_RGB pixel = { bitmap->pixel_data[(i*bitmap->width + j)*3 + 0],
                       bitmap->pixel_data[(i*bitmap->width + j)*3 + 1],
                       bitmap->pixel_data[(i*bitmap->width + j)*3 + 2] };
 
@@ -39,7 +39,7 @@ void drawBitmap(int16_t x, int16_t y, const gimp32x32bitmap* bitmap) {
 }
 
 void setup() {
-  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight);
+  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH);
 
   matrix.setBrightness(128);
 

--- a/examples/FastLED_Functions/FastLED_Functions.ino
+++ b/examples/FastLED_Functions/FastLED_Functions.ino
@@ -17,11 +17,11 @@
 #define kMatrixWidth  MATRIX_WIDTH
 #define kMatrixHeight MATRIX_HEIGHT
 
+#define COLOR_DEPTH 48
 const uint8_t kMatrixHeight = 32;       // known working: 16, 32
 const uint8_t kMatrixWidth = 32;        // known working: 32, 64
-const uint8_t kColorDepthRgb = 36;      // known working: 36, 48 (24 isn't efficient and has color correction issues)
 const uint8_t kDmaBufferRows = 4;       // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, kColorDepthRgb, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 // The 32bit version of our coordinates
 static uint16_t x;
@@ -55,7 +55,7 @@ void setup() {
   // Serial.println("resetting!");
   delay(3000);
 
-  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight);
+  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH);
 
   matrix.setBackgroundBrightness(96);
 
@@ -89,7 +89,7 @@ void loop() {
   static uint8_t circlex = 0;
   static uint8_t circley = 0;
 
-  rgb24 *buffer = matrix.backBuffer();
+  SM_RGB *buffer = matrix.backBuffer();
 
   static uint8_t ihue=0;
   fillnoise8();

--- a/examples/FastLED_Noise_Interpolation/FastLED_Noise_Interpolation.ino
+++ b/examples/FastLED_Noise_Interpolation/FastLED_Noise_Interpolation.ino
@@ -1,11 +1,11 @@
 #include<SmartMatrix3.h>
 #include<FastLED.h>
 
+#define COLOR_DEPTH 48
 const uint8_t kMatrixHeight = 32;       // known working: 16, 32
 const uint8_t kMatrixWidth = 32;        // known working: 32, 64
-const uint8_t kColorDepthRgb = 36;      // known working: 36, 48 (24 isn't efficient and has color correction issues)
 const uint8_t kDmaBufferRows = 4;       // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, kColorDepthRgb, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 // The 32bit version of our coordinates
 static uint16_t x;
@@ -39,7 +39,7 @@ void setup() {
   // Serial.println("resetting!");
   //delay(3000);
 
-  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight);
+  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH);
 
   matrix.setBrightness(25);
 
@@ -75,7 +75,7 @@ void loop() {
   static uint8_t ihue=0;
   fillnoise8();
 
-  rgb24 *buffer = matrix.backBuffer();
+  SM_RGB *buffer = matrix.backBuffer();
 
   for(int i = 0; i < kMatrixWidth; i++) {
     for(int j = 0; j < kMatrixHeight; j++) {

--- a/examples/FeatureDemo/FeatureDemo.ino
+++ b/examples/FeatureDemo/FeatureDemo.ino
@@ -7,16 +7,16 @@
 #include "colorwheel.c"
 #include "gimpbitmap.h"
 
+#define COLOR_DEPTH 48
 const uint8_t kMatrixHeight = 32;       // known working: 16, 32
 const uint8_t kMatrixWidth = 32;        // known working: 32, 64
-const uint8_t kColorDepthRgb = 48;      // known working: 36, 48 (24 isn't efficient and has color correction issues)
 const uint8_t kDmaBufferRows = 4;       // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, kColorDepthRgb, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 const int defaultBrightness = 100*(255/100);    // full brightness
 //const int defaultBrightness = 15*(255/100);    // dim: 15% brightness
 const int defaultScrollOffset = 6;
-const rgb24 defaultBackgroundColor = {0x40, 0, 0};
+const SM_RGB defaultBackgroundColor = {0x40, 0, 0};
 
 // Teensy 3.0 has the LED on pin 13
 const int ledPin = 13;
@@ -24,7 +24,7 @@ const int ledPin = 13;
 void drawBitmap(int16_t x, int16_t y, const gimp32x32bitmap* bitmap) {
   for(unsigned int i=0; i < bitmap->height; i++) {
     for(unsigned int j=0; j < bitmap->width; j++) {
-      rgb24 pixel = { bitmap->pixel_data[(i*bitmap->width + j)*3 + 0],
+      SM_RGB pixel = { bitmap->pixel_data[(i*bitmap->width + j)*3 + 0],
                       bitmap->pixel_data[(i*bitmap->width + j)*3 + 1],
                       bitmap->pixel_data[(i*bitmap->width + j)*3 + 2] };
 
@@ -40,7 +40,7 @@ void setup() {
 
     Serial.begin(38400);
 
-    SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, Rgb48);
+    SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, 48);
 
     matrix.setBrightness(defaultBrightness);
 
@@ -132,8 +132,8 @@ void loop() {
             radius = random(matrix.getScreenWidth());
             radius2 = random(matrix.getScreenWidth());
 
-            rgb24 fillColor = {(uint8_t)random(192), (uint8_t)random(192), (uint8_t)random(192)};
-            rgb24 outlineColor = {(uint8_t)random(192), (uint8_t)random(192), (uint8_t)random(192)};
+            SM_RGB fillColor = {(uint8_t)random(192), (uint8_t)random(192), (uint8_t)random(192)};
+            SM_RGB outlineColor = {(uint8_t)random(192), (uint8_t)random(192), (uint8_t)random(192)};
 
             switch (random(15)) {
             case 0:
@@ -225,7 +225,7 @@ void loop() {
         while (millis() - currentMillis < transitionTime) {
             int x0, y0;
 
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             if (millis() - currentMillis < transitionTime / 2) {
@@ -267,7 +267,7 @@ void loop() {
         unsigned long delayCounter = currentMillis;
 
         for (i = 0; i < matrix.getScreenWidth(); i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             color.red = 255 - 255.0 * fraction;
@@ -281,7 +281,7 @@ void loop() {
         }
 
         for (i = 0; i < matrix.getScreenHeight(); i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
             fraction -= 1.0;
             if (fraction < 0) fraction = 0.0;
@@ -303,7 +303,7 @@ void loop() {
         delayCounter = currentMillis;
 
         for (i = 0; i < matrix.getScreenWidth() * 2; i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             color.red = 255 - 255.0 * fraction;
@@ -317,7 +317,7 @@ void loop() {
         }
 
         for (i = 0; i < matrix.getScreenWidth() * 2; i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
             fraction -= 1.0;
             if (fraction < 0) fraction = 0.0;
@@ -351,7 +351,7 @@ void loop() {
         unsigned long delayCounter = currentMillis;
 
         for (i = 0; i < matrix.getScreenWidth(); i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             color.red = 255 - 255.0 * fraction;
@@ -365,7 +365,7 @@ void loop() {
         }
 
         for (i = 0; i < matrix.getScreenHeight(); i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
             fraction -= 1.0;
             if (fraction < 0) fraction = 0.0;
@@ -399,7 +399,7 @@ void loop() {
         unsigned long delayCounter = currentMillis;
 
         for (i = 0; i < matrix.getScreenWidth() * 2; i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             color.red = 255 - 255.0 * fraction;
@@ -417,7 +417,7 @@ void loop() {
         }
 
         for (i = matrix.getScreenWidth() * 2 / 3; i >= 0; i--) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
             fraction -= 1.0;
             if (fraction < 0) fraction = 0.0;
@@ -452,7 +452,7 @@ void loop() {
         unsigned long delayCounter = currentMillis;
 
         for (i = 0; i < matrix.getScreenWidth() / 2; i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             color.red = 255 - 255.0 * fraction;
@@ -465,7 +465,7 @@ void loop() {
             while (millis() < delayCounter);
         }
         for (i = 0; i < matrix.getScreenWidth(); i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
             fraction -= 1.0;
             if (fraction < 0) fraction = 0.0;
@@ -499,7 +499,7 @@ void loop() {
         unsigned long delayCounter = currentMillis;
 
         for (i = 0; i < matrix.getScreenWidth() / 2; i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             color.red = 255 - 255.0 * fraction;
@@ -512,7 +512,7 @@ void loop() {
             while (millis() < delayCounter);
         }
         for (i = 0; i < matrix.getScreenWidth(); i++) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
             fraction -= 1.0;
             if (fraction < 0) fraction = 0.0;
@@ -548,7 +548,7 @@ void loop() {
         unsigned long delayCounter = currentMillis;
 
         while (millis() - currentMillis < transitionTime) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime);
 
             color.red = random(256);
@@ -621,7 +621,7 @@ void loop() {
         currentMillis = millis();
 
         while (millis() - currentMillis < transitionTime) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             if (millis() - currentMillis < transitionTime / 2) {
@@ -814,7 +814,7 @@ void loop() {
         currentMillis = millis();
 
         while (millis() - currentMillis < transitionTime) {
-            rgb24 color;
+            SM_RGB color;
             float fraction = ((float)millis() - currentMillis) / ((float)transitionTime / 2);
 
             if (millis() - currentMillis < transitionTime / 2) {
@@ -1289,7 +1289,7 @@ void loop() {
         while (millis() - currentMillis < transitionTime) {
             int x0, y0;
 
-            rgb24 color;
+            SM_RGB color;
             x0 = random(matrix.getScreenWidth());
             y0 = random(matrix.getScreenHeight());
 

--- a/examples/Gradient/Gradient.ino
+++ b/examples/Gradient/Gradient.ino
@@ -3,33 +3,32 @@
 // Change the following value to 24 or 48 to change between storing colors
 // with 24 or 48bits. At 24bits, this example sketch shows "stepping" at low
 // color values, while at 48bits the gradient is smooth.
-#define DEPTH 48
+#define COLOR_DEPTH 48                      // known working: 48, 24
 
 #define WIDTH 64
 #define HEIGHT 32
 
-#define PWM_DEPTH 48                      // known working: 48 (24 not yet supported)
 const uint8_t kMatrixHeight = HEIGHT;     // known working: 16, 32
 const uint8_t kMatrixWidth = WIDTH;       // known working: 32, 64
 const uint8_t kDmaBufferRows = 4;         // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, DEPTH, PWM_DEPTH, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 void setup() {
   //Serial.begin(115200);
-  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, DEPTH);
+  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH);
 
   matrix.setBrightness(255);
   matrix.setColorCorrection(cc48);
 }
 
 void loop() {
-  uint32_t max = pow(2, DEPTH/3) - 1;
+  uint32_t max = pow(2, COLOR_DEPTH/3) - 1;
   
   for (int x=0; x<WIDTH; x++) {
     uint32_t val = max * pow(x / double(WIDTH), 2) / 20;
     for (int y=0; y<HEIGHT; y++) {
       int pos = y * WIDTH + x;
-      RGB_TYPE(DEPTH)& pixel = matrix.backBuffer()[pos];
+      SM_RGB& pixel = matrix.backBuffer()[pos];
       pixel.red = val;
     }
   }

--- a/examples/MatrixClock/MatrixClock.ino
+++ b/examples/MatrixClock/MatrixClock.ino
@@ -15,16 +15,16 @@
 #include <DS1307RTC.h>
 #include <SmartMatrix3.h>
 
+#define COLOR_DEPTH 48
 const uint8_t kMatrixHeight = 32;       // known working: 16, 32
 const uint8_t kMatrixWidth = 32;        // known working: 32, 64
-const uint8_t kColorDepthRgb = 36;      // known working: 36, 48 (24 isn't efficient and has color correction issues)
 const uint8_t kDmaBufferRows = 4;       // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, kColorDepthRgb, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 const int defaultBrightness = 100*(255/100);    // full brightness
 //const int defaultBrightness = 15*(255/100);    // dim: 15% brightness
 
-const rgb24 clockColor = {0xff, 0xff, 0xff};
+const SM_RGB clockColor = {0xff, 0xff, 0xff};
 
 void setup() {
   Serial.begin(9600);
@@ -41,7 +41,7 @@ void setup() {
 
   // setup matrix
 
-  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight);
+  SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH);
   matrix.setBrightness(defaultBrightness);
   matrix.setColorCorrection(cc24);  
   matrix.setScrollFont(font3x5);

--- a/examples/SpectrumAnalyzer/SpectrumAnalyzer.ino
+++ b/examples/SpectrumAnalyzer/SpectrumAnalyzer.ino
@@ -29,11 +29,11 @@
 #include <SmartMatrix3.h>
 #include <FastLED.h>
 
+#define COLOR_DEPTH 48
 const uint8_t kMatrixHeight = 32;       // known working: 16, 32
 const uint8_t kMatrixWidth = 32;        // known working: 32, 64
-const uint8_t kColorDepthRgb = 36;      // known working: 36, 48 (24 isn't efficient and has color correction issues)
 const uint8_t kDmaBufferRows = 4;       // known working: 4
-SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, kColorDepthRgb, kDmaBufferRows);
+SMARTMATRIX_ALLOCATE_BUFFERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH, 48, kDmaBufferRows);
 
 #define MATRIX_HEIGHT kMatrixHeight
 #define MATRIX_WIDTH kMatrixWidth
@@ -56,7 +56,7 @@ float level[16];
 // looks more pleasing to corresponds to human sound perception.
 int shown[16];
 
-const rgb24 black = CRGB(0, 0, 0);
+const SM_RGB black = CRGB(0, 0, 0);
 
 byte status = 0;
 
@@ -65,7 +65,7 @@ void setup()
     Serial.begin(9600);
 
     // Initialize Matrix
-    SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight);
+    SMARTMATRIX_SETUP_DEFAULT_LAYERS(kMatrixWidth, kMatrixHeight, COLOR_DEPTH);
 
     matrix.setBrightness(255);
 
@@ -120,7 +120,7 @@ void loop()
             }
 
             // color hue based on band
-            rgb24 color = CRGB(CHSV(i * 15, 255, 255));
+            SM_RGB color = CRGB(CHSV(i * 15, 255, 255));
 
             // draw the levels on the matrix
             if (shown[i] >= 0) {


### PR DESCRIPTION
Here are some fixes to the examples. Basically I changed them to use the new macro argument list and changed the types to SM_RGB which is defined based on the depth passed to the `SMARTMATRIX_ALLOCATE_BUFFERS` macro.

I haven't run them, only compiled since I don't have a teensy here. I couldn't get some of the fastled ones to compile fully. It seems like it was expecting some implicit copy constructor or something being called to convert from an CRGB to rgb24 but I can't find it's definition anywhere.