### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,7 +23,7 @@ SMLayerIndexed	KEYWORD1
 begin	KEYWORD2
 addLayer	KEYWORD2
 
-setRotation KEYWORD2
+setRotation	KEYWORD2
 setBrightness	KEYWORD2
 setRefreshRate	KEYWORD2
 
@@ -33,7 +33,7 @@ getRefreshRate	KEYWORD2
 getdmaBufferUnderrunFlag	KEYWORD2
 getRefreshRateLoweredFlag	KEYWORD2
 
-countFPS KEYWORD2
+countFPS	KEYWORD2
 
 # Layer class
 frameRefreshCallback	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords