### PR TITLE
fix unexplained 10 char limit in drawstring

### DIFF
--- a/src/Layer_Background_Impl.h
+++ b/src/Layer_Background_Impl.h
@@ -798,12 +798,7 @@ void SMLayerBackground<RGB, optionFlags>::drawString(int16_t x, int16_t y, const
     int xcnt, ycnt, i = 0, offset = 0;
     char character;
 
-    // limit text to 10 chars, why?
-    for (i = 0; i < 10; i++) {
-        character = text[offset++];
-        if (character == '\0')
-            return;
-
+    while ((character = text[offset++]) != '\0') {
         for (ycnt = 0; ycnt < font->Height; ycnt++) {
             for (xcnt = 0; xcnt < font->Width; xcnt++) {
                 if (getBitmapFontPixelAtXY(character, xcnt, ycnt, font)) {
@@ -821,12 +816,7 @@ void SMLayerBackground<RGB, optionFlags>::drawString(int16_t x, int16_t y, const
     int xcnt, ycnt, i = 0, offset = 0;
     char character;
 
-    // limit text to 10 chars, why?
-    for (i = 0; i < 10; i++) {
-        character = text[offset++];
-        if (character == '\0')
-            return;
-
+    while ((character = text[offset++]) != '\0') {
         for (ycnt = 0; ycnt < font->Height; ycnt++) {
             for (xcnt = 0; xcnt < font->Width; xcnt++) {
                 if (getBitmapFontPixelAtXY(character, xcnt, ycnt, font)) {


### PR DESCRIPTION
Fix https://github.com/pixelmatix/SmartMatrix/issues/57
I can't find a good reason to limit the draw size. If it runs out of the screen, it'll draw off screen without consequences I can think about.