### PR TITLE
Factor out ESP32 memory display.

### DIFF
--- a/src/ESP32MemDisplay.h
+++ b/src/ESP32MemDisplay.h
@@ -1,0 +1,42 @@
+/*
+ * SmartMatrix Library - ESP32 Memory Info
+ *
+ * Copyright (c) 2018 Louis Beaudoin (Pixelmatix)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _ESP32MEMDISPLAY_H_
+#define _ESP32MEMDISPLAY_H_
+
+static void show_esp32_dma_mem(const char *str=NULL) {
+    if (str) {
+        printf("%s: %d bytes total, %d bytes largest free block\r\n", str, heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    } else {
+        printf("DMA Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    }
+}
+
+static void show_esp32_all_mem(void) {
+    printf("Heap Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
+    printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    printf("32-bit Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
+    show_esp32_dma_mem();
+}
+
+#endif

--- a/src/SmartMatrixMultiplexedRefreshEsp32_Impl.h
+++ b/src/SmartMatrixMultiplexedRefreshEsp32_Impl.h
@@ -38,6 +38,7 @@
 #include "i2s_parallel.h"
 #endif
 
+#include "ESP32MemDisplay.h"
 #include "driver/mcpwm.h"
 #include "soc/mcpwm_reg.h"
 #include "soc/mcpwm_struct.h"
@@ -194,16 +195,15 @@ void SmartMatrix3RefreshMultiplexed<refreshDepth, matrixWidth, matrixHeight, pan
     assert(matrixUpdateFrames[1] != NULL);
 
     printf("sizeof framestruct: %08X\r\n", (uint32_t)sizeof(frameStruct));
+    show_esp32_dma_mem("DMA Memory Available before ptr1 alloc");
     printf("matrixUpdateFrames[0] pointer: %08X\r\n", (uint32_t)matrixUpdateFrames[0]);
+    show_esp32_dma_mem("DMA Memory Available before ptr2 alloc");
     printf("matrixUpdateFrames[1] pointer: %08X\r\n", (uint32_t)matrixUpdateFrames[1]);
 
     printf("Frame Structs Allocated from Heap:\r\n");
-    printf("Heap Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
-    printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-    printf("32-bit Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
-    printf("DMA Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    show_esp32_all_mem();
 
-    printf("Allocating refresh buffer:\r\nDMA Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    printf("Allocating refresh buffer:\r\n");
 
     // setup debug output
 #ifdef DEBUG_PINS_ENABLED
@@ -305,10 +305,7 @@ void SmartMatrix3RefreshMultiplexed<refreshDepth, matrixWidth, matrixHeight, pan
     }
 
     printf("SmartMatrix Mallocs Complete\r\n");
-    printf("Heap Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
-    printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-    printf("32-bit Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
-    printf("DMA Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    show_esp32_all_mem();
 
     lldesc_t *prevdmadesca = 0;
     lldesc_t *prevdmadescb = 0;


### PR DESCRIPTION
Also show DMA memory before the first matrixUpdateFrames allocations
as they can fail and cause an assert/crash

This can also be used in external code, like
https://github.com/marcmerlin/AnimatedGIFs/commit/1750be0fb5062c8f29f4535e7e08e60036746032