### PR TITLE
Remove redundant memory display between Heap/32-bit and DMA/8-bit.

### DIFF
--- a/src/ESP32MemDisplay.h
+++ b/src/ESP32MemDisplay.h
@@ -24,19 +24,31 @@
 #ifndef _ESP32MEMDISPLAY_H_
 #define _ESP32MEMDISPLAY_H_
 
+static void show_esp32_heap_mem(const char *str=NULL) {
+    if (str) {
+    	printf("%s: %6d bytes total, %6d bytes largest free block\n", str, heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
+    } else {
+    	printf("Heap/32-bit Memory Available: %6d bytes total, %6d bytes largest free block\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
+    }
+}
+
+
 static void show_esp32_dma_mem(const char *str=NULL) {
     if (str) {
-        printf("%s: %d bytes total, %d bytes largest free block\r\n", str, heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+        printf("%s: %6d bytes total, %6d bytes largest free block\n", str, heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
     } else {
-        printf("DMA Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+        printf("8-bit/DMA Memory Available  : %6d bytes total, %6d bytes largest free block\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
     }
 }
 
 static void show_esp32_all_mem(void) {
-    printf("Heap Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
-    printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-    printf("32-bit Memory Available: %d bytes total, %d bytes largest free block\r\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
+    show_esp32_heap_mem();
+    // 32bit always seems to output the same value as Heap
+    // printf("32-bit Memory Available: %d bytes total, %d bytes largest free block\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
+
     show_esp32_dma_mem();
+    // 8-bit always seems to output the same value as DMA
+    //printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
 }
 
 #endif

--- a/src/SmartMatrixMultiplexedCalcEsp32_Impl.h
+++ b/src/SmartMatrixMultiplexedCalcEsp32_Impl.h
@@ -22,6 +22,7 @@
  */
 
 #include "SmartMatrix3.h"
+#include "ESP32MemDisplay.h"
 
 #define INLINE __attribute__( ( always_inline ) ) inline
 
@@ -297,10 +298,7 @@ template <int refreshDepth, int matrixWidth, int matrixHeight, unsigned char pan
 void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::begin(uint32_t dmaRamToKeepFreeBytes)
 {
     printf("\r\nStarting SmartMatrix Mallocs\r\n");
-    printf("Heap Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
-    printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-    printf("32-bit Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
-    printf("DMA Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(MALLOC_CAP_DMA), heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
+    show_esp32_all_mem();
 
     SM_Layer * templayer = baseLayer;
     while(templayer) {
@@ -313,7 +311,7 @@ void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlag
     xTaskCreate(calcTask, "SmartMatrixCalc", 1000, NULL, MATRIX_CALC_TASK_PRIORTY, &calcTaskHandle);
 
     printf("SmartMatrix Layers Allocated from Heap:\r\n");
-    printf("Heap Memory Available: %d bytes total, %d bytes largest free block: \r\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
+    show_esp32_heap_mem();
 
 #if defined(ESP32)
     // malloc temporary buffers needed for loadMatrixBuffers


### PR DESCRIPTION
From many runs, I've found that they are always the same on my ESP32,
so to make output as well as memory debug cut/paste output more
concise, I've collapsed them.

I also found other copies of the memory code and pointed them to
show_esp32_all_mem and the new show_esp32_heap_mem.

TESTED=New SM output at start:
Starting SmartMatrix Mallocs
Heap/32-bit Memory Available: 325548 bytes total, 113792 bytes largest free block
8-bit/DMA Memory Available: 239800 bytes total, 113792 bytes largest free block
SmartMatrix Layers Allocated from Heap:
Heap/32-bit Memory Available: 287168 bytes total, 113792 bytes largest free block
Starting SmartMatrix DMA Mallocs
sizeof framestruct: 0000C000
DMA Memory Available before ptr1 alloc: 101900 bytes total, 39960 bytes largest free block
matrixUpdateFrames[0] pointer: 3FFE4374
DMA Memory Available before ptr2 alloc: 101900 bytes total, 39960 bytes largest free block
matrixUpdateFrames[1] pointer: 3FFF0384
Frame Structs Allocated from Heap:
Heap/32-bit Memory Available: 187648 bytes total, 85748 bytes largest free block
8-bit/DMA Memory Available: 101900 bytes total, 39960 bytes largest free block
(...)