### PR TITLE
remove unused code that triggers build warnings

### DIFF
--- a/src/SmartMatrixMultiplexedCalcEsp32_Impl.h
+++ b/src/SmartMatrixMultiplexedCalcEsp32_Impl.h
@@ -505,6 +505,7 @@ INLINE void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, opt
             templayer = templayer->nextLayer;        
         }
 
+        /*
         union {
             uint8_t word;
             struct {
@@ -512,6 +513,7 @@ INLINE void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, opt
                 uint8_t GPIO_WORD_ORDER_8BIT;
             };
         } o0;
+        */
         
         for(int j=0; j<COLOR_DEPTH_BITS; j++) {
             int maskoffset = 0;
@@ -822,6 +824,7 @@ INLINE void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, opt
             templayer = templayer->nextLayer;        
         }
 
+/*
         union {
             uint8_t word;
             struct {
@@ -829,7 +832,8 @@ INLINE void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, opt
                 uint8_t GPIO_WORD_ORDER_8BIT;
             };
         } o0;
-        
+  */
+  
         for(int j=0; j<COLOR_DEPTH_BITS; j++) {
             int maskoffset = 0;
             if(COLOR_DEPTH_BITS == 12)   // 36-bit color


### PR DESCRIPTION
replaces https://github.com/pixelmatix/SmartMatrix/pull/67 which doesn't apply anymore