### PR TITLE
pin calc task to a specific core

### DIFF
--- a/src/SmartMatrixMultiplexedCalcEsp32.h
+++ b/src/SmartMatrixMultiplexedCalcEsp32.h
@@ -27,6 +27,10 @@
 extern SemaphoreHandle_t calcTaskSemaphore;
 extern void matrixCalculationsSignal(void);
 
+#if !defined(DEFAULT_CALC_TASK_CORE)
+#define DEFAULT_CALC_TASK_CORE 1
+#endif
+
 template <int refreshDepth, int matrixWidth, int matrixHeight, unsigned char panelType, unsigned char optionFlags>
 class SmartMatrix3 {
 public:
@@ -36,7 +40,7 @@ public:
 
     // init
     SmartMatrix3(void);
-    void begin(uint32_t dmaRamToKeepFreeBytes = 0);
+    void begin(uint32_t dmaRamToKeepFreeBytes = 0, uint32_t core = DEFAULT_CALC_TASK_CORE);
     void addLayer(SM_Layer * newlayer);
 
     // configuration

--- a/src/SmartMatrixMultiplexedCalcEsp32_Impl.h
+++ b/src/SmartMatrixMultiplexedCalcEsp32_Impl.h
@@ -295,7 +295,7 @@ void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlag
 #define MATRIX_CALC_TASK_PRIORTY 2
 
 template <int refreshDepth, int matrixWidth, int matrixHeight, unsigned char panelType, unsigned char optionFlags>
-void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::begin(uint32_t dmaRamToKeepFreeBytes)
+void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::begin(uint32_t dmaRamToKeepFreeBytes, uint32_t core)
 {
     printf("\r\nStarting SmartMatrix Mallocs\r\n");
     show_esp32_all_mem();
@@ -308,7 +308,7 @@ void SmartMatrix3<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlag
 
     calcTaskSemaphore = xSemaphoreCreateBinary();
     // TODO: fine tune stack size: 1000 works with 64x64/32-24bit, 500 doesn't, does it change based on matrix size, depth?
-    xTaskCreate(calcTask, "SmartMatrixCalc", 1000, NULL, MATRIX_CALC_TASK_PRIORTY, &calcTaskHandle);
+    xTaskCreatePinnedToCore(calcTask, "SmartMatrixCalc", 1000, NULL, MATRIX_CALC_TASK_PRIORTY, &calcTaskHandle, core);
 
     printf("SmartMatrix Layers Allocated from Heap:\r\n");
     show_esp32_heap_mem();


### PR DESCRIPTION
compile time can set the default
override-able at run time in begin()

Fixes #102
