### PR TITLE
Handle PSRAM if available and enabled at compile time.

### DIFF
--- a/src/ESP32MemDisplay.h
+++ b/src/ESP32MemDisplay.h
@@ -24,11 +24,17 @@
 #ifndef _ESP32MEMDISPLAY_H_
 #define _ESP32MEMDISPLAY_H_
 
+#ifdef BOARD_HAS_PSRAM
+#define ESPmalloc ps_malloc
+#else
+#define ESPmalloc malloc
+#endif
+
 static void show_esp32_heap_mem(const char *str=NULL) {
     if (str) {
-    	printf("%s: %6d bytes total, %6d bytes largest free block\n", str, heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
+    	printf("%s: %6d bytes total, %6d bytes largest free block\n", str, heap_caps_get_free_size(MALLOC_CAP_INTERNAL), heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
     } else {
-    	printf("Heap/32-bit Memory Available: %6d bytes total, %6d bytes largest free block\n", heap_caps_get_free_size(0), heap_caps_get_largest_free_block(0));
+    	printf("Heap/32-bit Memory Available: %6d bytes total, %6d bytes largest free block\n", heap_caps_get_free_size(MALLOC_CAP_INTERNAL), heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
     }
 }
 
@@ -41,14 +47,20 @@ static void show_esp32_dma_mem(const char *str=NULL) {
     }
 }
 
+static void show_esp32_psram() {
+#ifdef BOARD_HAS_PSRAM
+    Serial.print("Total PSRAM used: ");
+    Serial.print(ESP.getPsramSize() - ESP.getFreePsram());
+    Serial.print(" bytes total, ");
+    Serial.print(ESP.getFreePsram());
+    Serial.println(" PSRAM bytes free");
+#endif
+}
+
 static void show_esp32_all_mem(void) {
     show_esp32_heap_mem();
-    // 32bit always seems to output the same value as Heap
-    // printf("32-bit Memory Available: %d bytes total, %d bytes largest free block\n", heap_caps_get_free_size(MALLOC_CAP_32BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));
-
     show_esp32_dma_mem();
-    // 8-bit always seems to output the same value as DMA
-    //printf("8-bit Accessible Memory Available: %d bytes total, %d bytes largest free block\n", heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    show_esp32_psram();
 }
 
 #endif

--- a/src/Layer_Background_Impl.h
+++ b/src/Layer_Background_Impl.h
@@ -42,12 +42,17 @@ SMLayerBackground<RGB, optionFlags>::SMLayerBackground(uint16_t width, uint16_t 
 template <typename RGB, unsigned int optionFlags>
 void SMLayerBackground<RGB, optionFlags>::begin(void) {
 #if defined(ESP32)
+#ifdef BOARD_HAS_PSRAM
+#define ESPmalloc ps_malloc
+#else
+#define ESPmalloc malloc
+#endif
     if(!backgroundBuffers[0] && !backgroundBuffers[1]) {
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
-        backgroundBuffers[0] = (RGB *)malloc(sizeof(RGB) * this->matrixWidth * this->matrixHeight);
+        backgroundBuffers[0] = (RGB *)ESPmalloc(sizeof(RGB) * this->matrixWidth * this->matrixHeight);
         assert(backgroundBuffers[0] != NULL);
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
-        backgroundBuffers[1] = (RGB *)malloc(sizeof(RGB) * this->matrixWidth * this->matrixHeight);
+        backgroundBuffers[1] = (RGB *)ESPmalloc(sizeof(RGB) * this->matrixWidth * this->matrixHeight);
         assert(backgroundBuffers[1] != NULL);
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
         memset(backgroundBuffers[0], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -68,6 +68,7 @@
     #pragma message "Jason Coon ESP32 NodeMCU shield wiring"
 // This pinout takes a ribbon cable and flattens it, pin order is 1, 9, 2, 10 ...
 // it connects to https://www.tindie.com/products/jasoncoon/16-output-nodemcu-esp32-wifi-ble-led-controller/
+// https://cdn.tindiemedia.com/images/resize/byvBO67Uofqr3gmoYuaBRB-dLXE=/p/fit-in/1370x912/filters:fill(fff)/i/13194/products/2018-10-27T20%3A22%3A44.751Z-IMG_20181026_082016725.jpg
 // *** WARNING, I cut the trace on Jason's board that went to pin 3, and patched a wire
 // to pin 27 so that I can use RX/TX serial debugging ****
 // That shield's pinout is this for the output of the level shifters:
@@ -136,6 +137,8 @@
     #pragma message "Jason Coon ESP32 Wemos/Lolin shield wiring"
 // This pinout takes a ribbon cable and flattens it, pin order is 1, 9, 2, 10 ...
 // it connects to https://www.tindie.com/products/jasoncoon/16-output-wemos-d32-wifi-ble-led-controller/
+// https://cdn.tindiemedia.com/images/resize/CAcVhrbEJscOrGie3xfCipyhNMU=/p/fit-in/1370x912/filters:fill(fff)/i/13194/products/2019-12-22T16%3A13%3A12.396Z-Board%20Top.png
+// This is the shield you want to use for PSRAM as it requires pins 16 and 17 to be left alone.
 // *** WARNING, I cut the trace on Jason's board that went to pin 3, and patched a wire
 // to pin 27 so that I can use RX/TX serial debugging ****
 // That shield's pinout is this for the output of the level shifters:


### PR DESCRIPTION
Enabling PSRAM in the arduino GUI sets BOARD_HAS_PSRAM
If it is defined, show PSRAM used/free along with rest of memory.
Also fix heap_caps_get_free_size(MALLOC_CAP_INTERNAL) (using 0 was not correct).
Allow allocating PSRAM for background buffers.