### PR TITLE
fix(FastLED_Functions): remove seam (#81)

### DIFF
--- a/examples/FastLed_Functions/FastLed_Functions.ino
+++ b/examples/FastLed_Functions/FastLed_Functions.ino
@@ -58,7 +58,8 @@ uint16_t speed = 20; // a nice starting speed, mixes well with a scale of 100
 uint16_t scale = 31;
 
 // This is the array that we keep our computed noise values in
-uint8_t noise[kMatrixWidth][kMatrixHeight];
+const uint16_t kMatrixLongestSide = (kMatrixWidth > kMatrixHeight) ? kMatrixWidth : kMatrixHeight;
+uint8_t noise[kMatrixLongestSide][kMatrixLongestSide];
 
 void setup() {
   // Enable printing FPS count information
@@ -89,9 +90,9 @@ void setup() {
 
 // Fill the x/y array of 8-bit noise values using the inoise8 function.
 void fillnoise8() {
-  for(int i = 0; i < kMatrixWidth; i++) {
+  for(int i = 0; i < kMatrixLongestSide; i++) {
     int ioffset = scale * i;
-    for(int j = 0; j < kMatrixHeight; j++) {
+    for(int j = 0; j < kMatrixLongestSide; j++) {
       int joffset = scale * j;
       noise[i][j] = inoise8(x + ioffset,y + joffset,z);
     }

--- a/examples/FastLed_Panel_Plus_Apa102/FastLed_Panel_Plus_Apa102.ino
+++ b/examples/FastLed_Panel_Plus_Apa102/FastLed_Panel_Plus_Apa102.ino
@@ -85,21 +85,21 @@ uint16_t speed = 1; // almost looks like a painting, moves very slowly
 uint16_t scale = 31;
 
 #if (ENABLE_APA102_REFRESH == 1)
-#define MAX_DIMENSION_APA ((kApaMatrixWidth>kApaMatrixHeight) ? kApaMatrixWidth : kApaMatrixHeight)
+const uint16_t kApaMatrixLongestSide = (kApaMatrixWidth>kApaMatrixHeight) ? kApaMatrixWidth : kApaMatrixHeight;
 #else
-#define MAX_DIMENSION_APA 0
+const uint16_t kApaMatrixLongestSide = 0;
 #endif
 
 #if (ENABLE_HUB75_REFRESH == 1)
-#define MAX_DIMENSION_PANEL ((kMatrixWidth>kMatrixHeight) ? kMatrixWidth : kMatrixHeight)
+const uint16_t kMatrixLongestSide = (kMatrixWidth > kMatrixHeight) ? kMatrixWidth : kMatrixHeight;
 #else
-#define MAX_DIMENSION_PANEL 0
+const uint16_t kMatrixLongestSide = 0;
 #endif
 
-#define MAX_DIMENSION_OVERALL ((MAX_DIMENSION_APA>MAX_DIMENSION_PANEL) ? MAX_DIMENSION_APA : MAX_DIMENSION_PANEL)
+const uint16_t kLongestSideOverall = (kApaMatrixLongestSide > kMatrixLongestSide) ? kApaMatrixLongestSide : kMatrixLongestSide;
 
 // This is the array that we keep our computed noise values in
-uint8_t noise[MAX_DIMENSION_OVERALL][MAX_DIMENSION_OVERALL];
+uint8_t noise[kLongestSideOverall][kLongestSideOverall];
 
 uint16_t XY(uint8_t x, uint8_t y) {
   return kApaMatrixWidth * y + x;
@@ -176,9 +176,9 @@ void setup() {
 
 // Fill the x/y array of 8-bit noise values using the inoise8 function.
 void fillnoise8() {
-  for(int i = 0; i < MAX_DIMENSION_OVERALL; i++) {
+  for(int i = 0; i < kLongestSideOverall; i++) {
     int ioffset = scale * i;
-    for(int j = 0; j < MAX_DIMENSION_OVERALL; j++) {
+    for(int j = 0; j < kLongestSideOverall; j++) {
       int joffset = scale * j;
       noise[i][j] = inoise8(x + ioffset,y + joffset,z);
     }

--- a/examples/MultipleTextLayersGfx/MultipleTextLayersGfx.ino
+++ b/examples/MultipleTextLayersGfx/MultipleTextLayersGfx.ino
@@ -161,13 +161,14 @@ uint16_t speed = 10; // a nice starting speed, mixes well with a scale of 100
 uint16_t scale = 31;
 
 // This is the array that we keep our computed noise values in
-uint8_t noise[kMatrixWidth][kMatrixHeight];
+const uint16_t kMatrixLongestSide = (kMatrixWidth > kMatrixHeight) ? kMatrixWidth : kMatrixHeight;
+uint8_t noise[kMatrixLongestSide][kMatrixLongestSide];
 
 // Fill the x/y array of 8-bit noise values using the inoise8 function.
 void fillnoise8() {
-  for(int i = 0; i < kMatrixWidth; i++) {
+  for(int i = 0; i < kMatrixLongestSide; i++) {
     int ioffset = scale * i;
-    for(int j = 0; j < kMatrixHeight; j++) {
+    for(int j = 0; j < kMatrixLongestSide; j++) {
       int joffset = scale * j;
       noise[i][j] = inoise8(x + ioffset,y + joffset,z);
     }


### PR DESCRIPTION
This should fix the seam in the noise on non-rectangular layouts.  The same problem was reported in r/FastLED a few days ago.

I've had a P2 128x64 matrix for over a year.  It arrived just before I moved house, and it has only just resurfaced and reminded me of its existence.

I received a SmartLED Shield v5 yesterday.  This afternoon I started reading and soldering.  Before my soldering iron has cooled down, I'm up and running.  I wasn't at all confident at the outset,  but thanks to your excellent documentation I'm grinning at 8,192 scintillating RGB LEDs.

Thanks for giving me such a great start, Louis.