### PR TITLE
Add "peek" scrolling modes

### DIFF
--- a/src/Layer_Gfx_Mono_Impl.h
+++ b/src/Layer_Gfx_Mono_Impl.h
@@ -484,6 +484,21 @@ void SMLayerGFXMono<RGB_API, RGB_STORAGE, optionFlags>::updateScrollingText(void
         }
         break;
 
+    case peekForward:
+        SHIFT_SCROLL_POSITION_LEFT();
+        if (IS_SCROLL_POSITION_FULLY_LEFT()) {
+            scrollmode = peekReverse;
+            if (scrollcounter > 0) scrollcounter--;
+        }
+        break;
+
+    case peekReverse:
+        SHIFT_SCROLL_POSITION_RIGHT();
+        if (IS_SCROLL_POSITION_FULLY_RIGHT()) {
+            scrollmode = peekForward;
+            if (scrollcounter > 0) scrollcounter--;
+        }
+        break;
     default:
     case stopped:
         SET_SCROLL_POSITION_TO_OFFSET_FROM_LEFT(fontLeftOffset);
@@ -637,11 +652,21 @@ void SMLayerGFXMono<RGB_API, RGB_STORAGE, optionFlags>::setMinMax(void) {
             // TODO: handle special case - put content in fixed location if wider than window
 
             break;
+        case peekForward:
+        case peekReverse:
+            scrollMin = ((this->layerRotation % 2) ? this->matrixHeight : this->matrixWidth) - textWidth;
+            scrollMin = (scrollMin > 0) ? 0 : scrollMin;
+            scrollMax = 0;
 
+            SET_SCROLL_POSITION_TO_RIGHT();
+            if (scrollmode == peekReverse)
+                SET_SCROLL_POSITION_TO_LEFT();
+
+            break;
         case stopped:
         case off:
             SET_SCROLL_POSITION_TO_OFFSET_FROM_LEFT(fontLeftOffset);
-        break;
+            break;
     }
 }
 
@@ -659,7 +684,7 @@ void SMLayerGFXMono<RGB_API, RGB_STORAGE, optionFlags>::stop(void) {
     // scrollcounter is next to zero
     scrollcounter = 1;
     // position text at the end of the cycle
-    if(scrollmode == bounceReverse)
+    if(scrollmode == bounceReverse || scrollmode == peekReverse)
         SET_SCROLL_POSITION_TO_RIGHT();
     else
         SET_SCROLL_POSITION_TO_LEFT();

--- a/src/Layer_Scrolling_Impl.h
+++ b/src/Layer_Scrolling_Impl.h
@@ -215,7 +215,17 @@ void SMLayerScrolling<RGB, optionFlags>::setMinMax(void) {
         // TODO: handle special case - put content in fixed location if wider than window
 
         break;
+    case peekForward:
+    case peekReverse:
+        scrollMin = this->localWidth - textWidth;
+        scrollMin = (scrollMin > 0) ? 0 : scrollMin;
+        scrollMax = 0;
 
+        scrollPosition = scrollMax;
+        if (scrollmode == peekReverse)
+            scrollPosition = scrollMin;
+
+        break;
     case stopped:
     case off:
         scrollMin = scrollMax = scrollPosition = 0;
@@ -286,6 +296,22 @@ void SMLayerScrolling<RGB, optionFlags>::updateScrollingText(void) {
         scrollPosition++;
         if (scrollPosition >= scrollMax) {
             scrollmode = bounceForward;
+            if (scrollcounter > 0) scrollcounter--;
+        }
+        break;
+
+    case peekForward:
+        scrollPosition--;
+        if (scrollPosition <= scrollMin) {
+            scrollmode = peekReverse;
+            if (scrollcounter > 0) scrollcounter--;
+        }
+        break;
+
+    case peekReverse:
+        scrollPosition++;
+        if (scrollPosition >= scrollMax) {
+            scrollmode = peekForward;
             if (scrollcounter > 0) scrollcounter--;
         }
         break;

--- a/src/MatrixCommon.h
+++ b/src/MatrixCommon.h
@@ -1017,7 +1017,9 @@ typedef enum ScrollMode {
     bounceReverse = 2,
     stopped = 3,
     off = 4,
-    wrapForwardFromLeft = 5
+    wrapForwardFromLeft = 5,
+    peekForward = 6,
+    peekReverse = 7
 } ScrollMode;
 
 #ifndef SWAPint


### PR DESCRIPTION
The "peek" modes scroll the text without allowing the start and end of the text within the display's bounds. That is, the display never shows empty space if the text is longer than the display.

My current project uses an ESP without the Adafruit GFX libraries, so I have implemented for both Layers that implement scrolling capability, however I have tested both implementations.

Resolves #158 

