### PR TITLE
Layers private members made protected

### DIFF
--- a/src/Layer_Background.h
+++ b/src/Layer_Background.h
@@ -84,7 +84,7 @@ class SMLayerBackground : public SM_Layer {
         void setBrightness(uint8_t brightness);
         void enableColorCorrection(bool enabled);
 
-    private:
+    protected:
         bool ccEnabled = true;
 
         RGB *currentDrawBufferPtr;

--- a/src/Layer_BackgroundGfx.h
+++ b/src/Layer_BackgroundGfx.h
@@ -121,7 +121,7 @@ class SMLayerBackgroundGFX : public SM_Layer, public Adafruit_GFX {
         using Adafruit_GFX::drawFastVLine;
         using Adafruit_GFX::drawFastHLine;
 
-    private:
+    protected:
         // Note we'd use a function template for the public functions but are keeping them fixed with rgb24/rgb48 parameters for backwards compatibility
         template <typename RGB_OUT>
         void fillRefreshRowTemplated(uint16_t hardwareY, RGB_OUT refreshRow[], int brightnessShifts);

--- a/src/Layer_Gfx_Mono.h
+++ b/src/Layer_Gfx_Mono.h
@@ -104,7 +104,7 @@ class SMLayerGFXMono : public SM_Layer, public Adafruit_GFX {
         inline void fillScreen(int color) { fillScreen((rgb1)(color > 0)); };
         inline void drawPixel(int16_t x, int16_t y, int color) { drawPixel(x, y, (rgb1)(color > 0)); };
 
-    private:
+    protected:
         /* RGB specific */
         void handleBufferSwap(void);
 

--- a/src/Layer_Indexed.h
+++ b/src/Layer_Indexed.h
@@ -55,7 +55,7 @@ class SMLayerIndexed : public SM_Layer {
         void drawString(int16_t x, int16_t y, uint8_t index, const char text []);
         void drawMonoBitmap(int16_t x, int16_t y, uint8_t width, uint8_t height, uint8_t index, uint8_t *bitmap);
 
-    private:
+    protected:
         // todo: move somewhere else
         static bool getBitmapPixelAtXY(uint8_t x, uint8_t y, uint8_t width, uint8_t height, const uint8_t *bitmap);
 

--- a/src/Layer_Scrolling.h
+++ b/src/Layer_Scrolling.h
@@ -62,7 +62,7 @@ class SMLayerScrolling : public SM_Layer {
         void setStartOffsetFromLeft(int offset);
         void enableColorCorrection(bool enabled);
 
-    private:
+    protected:
         void redrawScrollingText(void);
         void setMinMax(void);
 

--- a/src/MatrixHardware_ESP32_HUB75AdapterLite_V0.h
+++ b/src/MatrixHardware_ESP32_HUB75AdapterLite_V0.h
@@ -37,7 +37,9 @@
 
 #define GPIOPINOUT HUB75_ADAPTER_LITE_V0_PINOUT
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: HUB75 Adapter Lite V0 pinout"
+#endif
 
 //Upper half RGB
 #define BIT_R1  (1<<0)   

--- a/src/MatrixHardware_ESP32_HUB75Adapter_SMT.h
+++ b/src/MatrixHardware_ESP32_HUB75Adapter_SMT.h
@@ -38,8 +38,9 @@
 
 #define GPIOPINOUT HUB75_ADAPTER_V0_SMT_PINOUT
 
-
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: HUB75 Adapter V0 SMT pinout"
+#endif
 
 //Upper half RGB
 #define BIT_R1  (1<<0)   

--- a/src/MatrixHardware_ESP32_HUB75Adapter_THT.h
+++ b/src/MatrixHardware_ESP32_HUB75Adapter_THT.h
@@ -38,7 +38,9 @@
 
 #define GPIOPINOUT HUB75_ADAPTER_V0_THT_PINOUT
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: HUB75 Adapter V0 THT pinout"
+#endif
 
 //Upper half RGB
 #define BIT_R1  (1<<0)   

--- a/src/MatrixHardware_ESP32_RGB64x32MatrixPanel-I2S-DMA_default.h
+++ b/src/MatrixHardware_ESP32_RGB64x32MatrixPanel-I2S-DMA_default.h
@@ -37,7 +37,9 @@
 
 #define GPIOPINOUT HUB75_ADAPTER_LITE_V0_PINOUT
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: ESP32-RGB64x32MatrixPanel-I2S-DMA default pinout"
+#endif
 
 //Upper half RGB
 #define BIT_R1  (1<<0)   

--- a/src/MatrixHardware_ESP32_SmartLedShieldV0.h
+++ b/src/MatrixHardware_ESP32_SmartLedShieldV0.h
@@ -46,7 +46,9 @@
 
 #define GPIOPINOUT SMARTLED_SHIELD_V0_PINOUT
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: ESP32 SmartLED shield V0 pinout"
+#endif
 
 //Upper half RGB
 #define BIT_R1  (1<<0)   

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -67,7 +67,11 @@
 
 
 #if (GPIOPINOUT == ESP32_JC_RIBBON_PINOUT)
+
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: Jason Coon ESP32 NodeMCU shield wiring"
+    #endif
+
 // This pinout takes a ribbon cable and flattens it, pin order is 1, 9, 2, 10 ...
 // it connects to https://www.tindie.com/products/jasoncoon/16-output-nodemcu-esp32-wifi-ble-led-controller/
 // *** WARNING, I cut the trace on Jason's board that went to pin 3, and patched a wire
@@ -135,7 +139,10 @@
     #define OE_PIN  GPIO_NUM_12
 
 #elif (GPIOPINOUT == ESP32_JC_RIBBON_PINOUT_WEMOS)
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: Jason Coon ESP32 Wemos/Lolin shield wiring"
+    #endif
+
 // This pinout takes a ribbon cable and flattens it, pin order is 1, 9, 2, 10 ...
 // it connects to https://www.tindie.com/products/jasoncoon/16-output-wemos-d32-wifi-ble-led-controller/
 // *** WARNING, I cut the trace on Jason's board that went to pin 3, and patched a wire
@@ -205,7 +212,9 @@
 
 #elif (GPIOPINOUT == ESP32_FORUM_PINOUT)
 
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: ESP32 forum wiring"
+    #endif
 
     // ADDX is output directly using GPIO
     #define CLKS_DURING_LATCH   0 
@@ -267,7 +276,9 @@
 
 #elif (GPIOPINOUT == HUB75_ADAPTER_PINOUT)
 
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: Hub75 Adapter Pinout"
+    #endif
 
     // ADDX is output directly using GPIO
     #define CLKS_DURING_LATCH   0 
@@ -328,7 +339,9 @@
     #define CLK_PIN GPIO_NUM_2
 
 #elif (GPIOPINOUT == ESP32_FORUM_PINOUT_WITH_LATCH)
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: ESP32 forum wiring with external 74AHCT373 latch circuit - note untested since 2018, may be broken"
+    #endif
 
     // Note: this is untested since 2018, may be broken
 
@@ -356,7 +369,9 @@
 
 #elif (GPIOPINOUT == SMARTLED_SHIELD_V0_PINOUT)
 
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: ESP32 SmartLED shield V0 pinout"
+    #endif
 
     // ADDX is output on RGB pins and stored in external latch (need multiple of 32-bits for full data struct, so pad 2 CLKs to 4 here)
     #define MATRIX_I2S_MODE I2S_PARALLEL_BITS_8
@@ -389,7 +404,9 @@
 
 #elif (GPIOPINOUT == HUB75_ADAPTER_LATCH_BREADBOARD_PINOUT)
 
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: HUB75 Adapter Latch Breadboard pinout"
+    #endif
 
     // ADDX is output on RGB pins and stored in external latch (need multiple of 32-bits for full data struct, so pad 2 CLKs to 4 here)
     #define MATRIX_I2S_MODE I2S_PARALLEL_BITS_8
@@ -422,7 +439,9 @@
 
 #elif (GPIOPINOUT == HUB75_ADAPTER_V0_THT_PINOUT)
 
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: HUB75 Adapter V0 THT pinout"
+    #endif
 
     // ADDX is output on RGB pins and stored in external latch (need multiple of 32-bits for full data struct, so pad 2 CLKs to 4 here)
     #define MATRIX_I2S_MODE I2S_PARALLEL_BITS_8
@@ -458,7 +477,9 @@
 
 #elif (GPIOPINOUT == HUB75_ADAPTER_V0_SMT_PINOUT)
 
+    #ifndef SM_INTERNAL
     #pragma message "MatrixHardware: HUB75 Adapter V0 SMT pinout"
+    #endif
 
     // ADDX is output on RGB pins and stored in external latch (need multiple of 32-bits for full data struct, so pad 2 CLKs to 4 here)
     #define MATRIX_I2S_MODE I2S_PARALLEL_BITS_8

--- a/src/MatrixHardware_Esp32_AtomLiteApaOnly.h
+++ b/src/MatrixHardware_Esp32_AtomLiteApaOnly.h
@@ -49,8 +49,9 @@
 #define BIT_E (1<<12)   
 
 
-
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: Atom Lite Apa102-Only"
+#endif
 
 // ADDX is output directly using GPIO
 #define CLKS_DURING_LATCH   0 

--- a/src/MatrixHardware_Teensy3_ShieldV1toV3.h
+++ b/src/MatrixHardware_Teensy3_ShieldV1toV3.h
@@ -26,7 +26,9 @@
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: SmartMatrix Shield for Teensy 3 V1-V3"
+#endif
 
 #define COLOR_CHANNELS_PER_PIXEL        3
 #define PIXELS_UPDATED_PER_CLOCK        2

--- a/src/MatrixHardware_Teensy3_ShieldV4.h
+++ b/src/MatrixHardware_Teensy3_ShieldV4.h
@@ -26,7 +26,9 @@
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: SmartLED Shield for Teensy 3 (V4)"
+#endif
 
 #define DMA_UPDATES_PER_CLOCK           2
 #define ADDX_UPDATE_ON_DATA_PINS

--- a/src/MatrixHardware_Teensy4_ShieldV0.h
+++ b/src/MatrixHardware_Teensy4_ShieldV0.h
@@ -38,7 +38,9 @@
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: SmartLED Shield for Teensy 4 V0"
+#endif
 
 /* an advanced user may need to tweak these values */
 

--- a/src/MatrixHardware_Teensy4_ShieldV4Adapter.h
+++ b/src/MatrixHardware_Teensy4_ShieldV4Adapter.h
@@ -44,7 +44,9 @@
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: Teensy 4 Adapter attached to SmartLED Shield for Teensy 3 (V4)"
+#endif
 
 /* an advanced user may need to tweak these values */
 

--- a/src/MatrixHardware_Teensy4_ShieldV4WireMod.h
+++ b/src/MatrixHardware_Teensy4_ShieldV4WireMod.h
@@ -41,7 +41,9 @@
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: Teensy 4 Wired to SmartLED Shield for Teensy 3 (V4)"
+#endif
 
 /* an advanced user may need to tweak these values */
 

--- a/src/MatrixHardware_Teensy4_ShieldV5.h
+++ b/src/MatrixHardware_Teensy4_ShieldV5.h
@@ -38,7 +38,9 @@
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
 
+#ifndef SM_INTERNAL
 #pragma message "MatrixHardware: SmartLED Shield for Teensy 4 (V5)"
+#endif
 
 /* an advanced user may need to tweak these values */
 


### PR DESCRIPTION
This is a fairly simply change, but is rather helpful in expanding the library with custom functions. In my project, I've created a derived class from Layer_Background, but several useful variables and functions are hidden due to them being private. By making them protected, they are accessible to derived classes that might need them.