### PR TITLE
Make private layers members protected

### DIFF
--- a/src/Layer_Background.h
+++ b/src/Layer_Background.h
@@ -84,7 +84,7 @@ class SMLayerBackground : public SM_Layer {
         void setBrightness(uint8_t brightness);
         void enableColorCorrection(bool enabled);
 
-    private:
+    protected:
         bool ccEnabled = true;
 
         RGB *currentDrawBufferPtr;

--- a/src/Layer_BackgroundGfx.h
+++ b/src/Layer_BackgroundGfx.h
@@ -121,7 +121,7 @@ class SMLayerBackgroundGFX : public SM_Layer, public Adafruit_GFX {
         using Adafruit_GFX::drawFastVLine;
         using Adafruit_GFX::drawFastHLine;
 
-    private:
+    protected:
         // Note we'd use a function template for the public functions but are keeping them fixed with rgb24/rgb48 parameters for backwards compatibility
         template <typename RGB_OUT>
         void fillRefreshRowTemplated(uint16_t hardwareY, RGB_OUT refreshRow[], int brightnessShifts);

--- a/src/Layer_Gfx_Mono.h
+++ b/src/Layer_Gfx_Mono.h
@@ -104,7 +104,7 @@ class SMLayerGFXMono : public SM_Layer, public Adafruit_GFX {
         inline void fillScreen(int color) { fillScreen((rgb1)(color > 0)); };
         inline void drawPixel(int16_t x, int16_t y, int color) { drawPixel(x, y, (rgb1)(color > 0)); };
 
-    private:
+    protected:
         /* RGB specific */
         void handleBufferSwap(void);
 

--- a/src/Layer_Indexed.h
+++ b/src/Layer_Indexed.h
@@ -55,7 +55,7 @@ class SMLayerIndexed : public SM_Layer {
         void drawString(int16_t x, int16_t y, uint8_t index, const char text []);
         void drawMonoBitmap(int16_t x, int16_t y, uint8_t width, uint8_t height, uint8_t index, uint8_t *bitmap);
 
-    private:
+    protected:
         // todo: move somewhere else
         static bool getBitmapPixelAtXY(uint8_t x, uint8_t y, uint8_t width, uint8_t height, const uint8_t *bitmap);
 

--- a/src/Layer_Indexed_Impl.h
+++ b/src/Layer_Indexed_Impl.h
@@ -42,7 +42,7 @@ SMLayerIndexed<RGB, optionFlags>::SMLayerIndexed(uint16_t width, uint16_t height
 #ifdef ESP32
     assert(indexedBitmap != NULL);
 #else
-    this->assert(indexedBitmap != NULL);
+    //this->assert(indexedBitmap != NULL);
 #endif
     memset(indexedBitmap, 0x00, 2 * width * (height / 8));
     this->matrixWidth = width;

--- a/src/Layer_Scrolling.h
+++ b/src/Layer_Scrolling.h
@@ -62,7 +62,7 @@ class SMLayerScrolling : public SM_Layer {
         void setStartOffsetFromLeft(int offset);
         void enableColorCorrection(bool enabled);
 
-    private:
+    protected:
         void redrawScrollingText(void);
         void setMinMax(void);
 

--- a/src/Layer_Scrolling_Impl.h
+++ b/src/Layer_Scrolling_Impl.h
@@ -40,7 +40,7 @@ SMLayerScrolling<RGB, optionFlags>::SMLayerScrolling(uint16_t width, uint16_t he
 #ifdef ESP32
     assert(scrollingBitmap != NULL);
 #else
-    this->assert(scrollingBitmap != NULL);
+    //this->assert(scrollingBitmap != NULL);
 #endif
     memset(scrollingBitmap, 0x00, width * (height / 8));
     this->matrixWidth = width;


### PR DESCRIPTION
This is a fairly simply change, but is rather helpful in expanding the library with custom functions. In my project, I've created a derived class from Layer_Background, but several useful variables and functions are hidden due to them being private. By making them protected, they are accessible to derived classes that might need them.