### PR TITLE
Fix compiler warnings in latest version of Teensyduino

### DIFF
--- a/src/Layer_BackgroundGfx_Impl.h
+++ b/src/Layer_BackgroundGfx_Impl.h
@@ -64,8 +64,8 @@ void SMLayerBackgroundGFX<RGB, optionFlags>::begin(void) {
         backgroundBuffers[1] = (RGB *)ESPmalloc(sizeof(RGB) * this->matrixWidth * this->matrixHeight);
         assert(backgroundBuffers[1] != NULL);
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
-        memset(backgroundBuffers[0], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
-        memset(backgroundBuffers[1], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
+        memset((void *)backgroundBuffers[0], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
+        memset((void *)backgroundBuffers[1], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
     }
     if(!backgroundColorCorrectionLUT) {
@@ -182,7 +182,7 @@ void SMLayerBackgroundGFX<RGB, optionFlags>::fillRefreshRow(uint16_t hardwareY, 
 
 template <typename RGB, unsigned int optionFlags>
 void SMLayerBackgroundGFX<RGB, optionFlags>::copyRefreshToDrawing() {
-    memcpy(currentDrawBufferPtr, currentRefreshBufferPtr, sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+    memcpy((void *)currentDrawBufferPtr, (void *)currentRefreshBufferPtr, sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
 }
 
 // waits until previous swap is complete
@@ -198,12 +198,12 @@ void SMLayerBackgroundGFX<RGB, optionFlags>::swapBuffers(bool copy) {
 #if 1
         // workaround for bizarre (optimization) bug - currentDrawBuffer and currentRefreshBuffer are volatile and are changed by an ISR while we're waiting for swapPending here.  They can't be used as parameters to memcpy directly though.  
         if(currentDrawBuffer)
-            memcpy(backgroundBuffers[1], backgroundBuffers[0], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+            memcpy((void *)backgroundBuffers[1], (void *)backgroundBuffers[0], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
         else
-            memcpy(backgroundBuffers[0], backgroundBuffers[1], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+            memcpy((void *)backgroundBuffers[0], (void *)backgroundBuffers[1], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
 #else
         // Similar code also drawing from volatile variables doesn't work if optimization is turned on: currentDrawBuffer will be equal to currentRefreshBuffer and cause a crash from memcpy copying a buffer to itself.  Why?
-        memcpy(backgroundBuffers[currentDrawBuffer], backgroundBuffers[currentRefreshBuffer], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+        memcpy((void *)backgroundBuffers[currentDrawBuffer], (void *)backgroundBuffers[currentRefreshBuffer], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
 
         // this also doesn't work
         //copyRefreshToDrawing();  

--- a/src/Layer_Background_Impl.h
+++ b/src/Layer_Background_Impl.h
@@ -60,8 +60,8 @@ void SMLayerBackground<RGB, optionFlags>::begin(void) {
         backgroundBuffers[1] = (RGB *)ESPmalloc(sizeof(RGB) * this->matrixWidth * this->matrixHeight);
         assert(backgroundBuffers[1] != NULL);
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
-        memset(backgroundBuffers[0], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
-        memset(backgroundBuffers[1], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
+        memset((void *)backgroundBuffers[0], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
+        memset((void *)backgroundBuffers[1], 0x00, sizeof(RGB) * this->matrixWidth * this->matrixHeight);
         //printf("largest free block %d: \r\n", heap_caps_get_largest_free_block(MALLOC_CAP_DMA));
     }
     if(!backgroundColorCorrectionLUT) {
@@ -971,12 +971,12 @@ void SMLayerBackground<RGB, optionFlags>::swapBuffers(bool copy) {
 #if 1
         // workaround for bizarre (optimization) bug - currentDrawBuffer and currentRefreshBuffer are volatile and are changed by an ISR while we're waiting for swapPending here.  They can't be used as parameters to memcpy directly though.  
         if(currentDrawBuffer)
-            memcpy(backgroundBuffers[1], backgroundBuffers[0], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+            memcpy((void *)backgroundBuffers[1], (void *)backgroundBuffers[0], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
         else
-            memcpy(backgroundBuffers[0], backgroundBuffers[1], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+            memcpy((void *)backgroundBuffers[0], (void *)backgroundBuffers[1], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
 #else
         // Similar code also drawing from volatile variables doesn't work if optimization is turned on: currentDrawBuffer will be equal to currentRefreshBuffer and cause a crash from memcpy copying a buffer to itself.  Why?
-        memcpy(backgroundBuffers[currentDrawBuffer], backgroundBuffers[currentRefreshBuffer], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+        memcpy((void *)backgroundBuffers[currentDrawBuffer], (void *)backgroundBuffers[currentRefreshBuffer], sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
 
         // this also doesn't work
         //copyRefreshToDrawing();  
@@ -990,7 +990,7 @@ void SMLayerBackground<RGB, optionFlags>::swapBuffers(bool copy) {
 
 template <typename RGB, unsigned int optionFlags>
 void SMLayerBackground<RGB, optionFlags>::copyRefreshToDrawing() {
-    memcpy(currentDrawBufferPtr, currentRefreshBufferPtr, sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
+    memcpy((void *)currentDrawBufferPtr, (void *)currentRefreshBufferPtr, sizeof(RGB) * (this->matrixWidth * this->matrixHeight));
 }
 
 // return pointer to start of currentDrawBuffer, so application can do efficient loading of bitmaps

--- a/src/Layer_Scrolling_Impl.h
+++ b/src/Layer_Scrolling_Impl.h
@@ -226,10 +226,14 @@ void SMLayerScrolling<RGB, optionFlags>::setMinMax(void) {
 
 template <typename RGB, unsigned int optionFlags>
 void SMLayerScrolling<RGB, optionFlags>::start(const char inputtext[], int numScrolls) {
-    int length = strlen((const char *)inputtext);
-    if (length > textLayerMaxStringLength)
-        length = textLayerMaxStringLength;
+    // int length = strlen((const char *)inputtext);
+    // if (length > textLayerMaxStringLength)
+    //     length = textLayerMaxStringLength;
+    int length = textLayerMaxStringLength;
+    if ((int)strlen((const char *)inputtext) < length)
+        length = strlen((const char *)inputtext);
     strncpy(text, (const char *)inputtext, length);
+    text[textLayerMaxStringLength-1] = '\0'; // add null-termination to fix compiler warning
     textlen = length;
     scrollcounter = numScrolls;
 
@@ -242,10 +246,14 @@ void SMLayerScrolling<RGB, optionFlags>::start(const char inputtext[], int numSc
 //Useful for a clock display where the time changes.
 template <typename RGB, unsigned int optionFlags>
 void SMLayerScrolling<RGB, optionFlags>::update(const char inputtext[]){
-    int length = strlen((const char *)inputtext);
-    if (length > textLayerMaxStringLength)
-        length = textLayerMaxStringLength;
+    // int length = strlen((const char *)inputtext);
+    // if (length > textLayerMaxStringLength)
+    //     length = textLayerMaxStringLength;
+    int length = textLayerMaxStringLength;
+    if ((int)strlen((const char *)inputtext) < length)
+        length = strlen((const char *)inputtext);
     strncpy(text, (const char *)inputtext, length);
+    text[textLayerMaxStringLength-1] = '\0'; // add null-termination to fix compiler warning
     textlen = length;
     textWidth = (textlen * scrollFont->Width) - 1;
 

--- a/src/MatrixCommonApa102Calc_Impl.h
+++ b/src/MatrixCommonApa102Calc_Impl.h
@@ -247,7 +247,7 @@ INLINE void SmartMatrixApaCalc<refreshDepth, matrixWidth, matrixHeight, panelTyp
     static rgb48 tempRow0[matrixWidth];
 
     // clear buffer to prevent garbage data showing through transparent layers
-    memset(tempRow0, 0x00, sizeof(tempRow0));
+    memset((void *)tempRow0, 0x00, sizeof(tempRow0));
 
     // get pixel data from layers
     SM_Layer * templayer = SmartMatrixApaCalc<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::baseLayer;

--- a/src/MatrixEsp32Hub75Calc_Impl.h
+++ b/src/MatrixEsp32Hub75Calc_Impl.h
@@ -514,8 +514,8 @@ INLINE void SmartMatrixHub75Calc<refreshDepth, matrixWidth, matrixHeight, panelT
     // go through this process for each physical row that is contained in the refresh row
     do {
         // clear buffer to prevent garbage data showing through transparent layers
-        memset(tempRow0, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
-        memset(tempRow1, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
+        memset((void *)tempRow0, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
+        memset((void *)tempRow1, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
 
 #if (REFRESH_PRINTFS >= 1)
         printf("multiRowRefreshRowOffset = %d\r\n", multiRowRefreshRowOffset);
@@ -841,8 +841,8 @@ INLINE void SmartMatrixHub75Calc<refreshDepth, matrixWidth, matrixHeight, panelT
     // go through this process for each physical row that is contained in the refresh row
     do {
         // clear buffer to prevent garbage data showing through transparent layers
-        memset(tempRow0, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
-        memset(tempRow1, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
+        memset((void *)tempRow0, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
+        memset((void *)tempRow1, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
 
         // get a row of physical pixel data (HUB75 paired) from the layers
         SM_Layer * templayer = SmartMatrixHub75Calc<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::baseLayer;

--- a/src/MatrixEsp32Hub75Calc_NT_Impl.h
+++ b/src/MatrixEsp32Hub75Calc_NT_Impl.h
@@ -450,8 +450,8 @@ INLINE void SmartMatrixHub75Calc_NT<dummyvar>::loadMatrixBuffers48(MATRIX_DATA_S
     // go through this process for each physical row that is contained in the refresh row
     do {
         // clear buffer to prevent garbage data showing through transparent layers
-        memset(tempRow0, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
-        memset(tempRow1, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
+        memset((void *)tempRow0, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
+        memset((void *)tempRow1, 0x00, sizeof(rgb48) * numPixelsPerTempRow);
 
 #if (REFRESH_PRINTFS >= 1)
         printf("multiRowRefreshRowOffset = %d\r\n", multiRowRefreshRowOffset);
@@ -778,8 +778,8 @@ INLINE void SmartMatrixHub75Calc_NT<dummyvar>::loadMatrixBuffers24(MATRIX_DATA_S
     // go through this process for each physical row that is contained in the refresh row
     do {
         // clear buffer to prevent garbage data showing through transparent layers
-        memset(tempRow0, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
-        memset(tempRow1, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
+        memset((void *)tempRow0, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
+        memset((void *)tempRow1, 0x00, sizeof(rgb24) * numPixelsPerTempRow);
 
         // get a row of physical pixel data (HUB75 paired) from the layers
         SM_Layer * templayer = baseLayer;

--- a/src/MatrixTeensy3Hub75Calc_Impl.h
+++ b/src/MatrixTeensy3Hub75Calc_Impl.h
@@ -363,8 +363,8 @@ INLINE void SmartMatrixHub75Calc<refreshDepth, matrixWidth, matrixHeight, panelT
     // go through this process for each physical row that is contained in the refresh row
     do {
         // clear buffer to prevent garbage data showing through transparent layers
-        memset(tempRow0, 0x00, sizeof(tempRow0));
-        memset(tempRow1, 0x00, sizeof(tempRow1));
+        memset((void *)tempRow0, 0x00, sizeof(tempRow0));
+        memset((void *)tempRow1, 0x00, sizeof(tempRow1));
 
         // get pixel data from layers
         SM_Layer * templayer = SmartMatrixHub75Calc<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::baseLayer;

--- a/src/MatrixTeensy4Hub75Calc_Impl.h
+++ b/src/MatrixTeensy4Hub75Calc_Impl.h
@@ -381,8 +381,8 @@ FASTRUN INLINE void SmartMatrixHub75Calc<refreshDepth, matrixWidth, matrixHeight
     // go through this process for each physical row that is contained in the refresh row
     do {
         // clear buffer to prevent garbage data showing
-        memset(tempRow0, 0, sizeof(tempRow0));
-        memset(tempRow1, 0, sizeof(tempRow1));
+        memset((void *)tempRow0, 0, sizeof(tempRow0));
+        memset((void *)tempRow1, 0, sizeof(tempRow1));
 
         // Get pixel data from layers and store in tempRow0 and tempRow1
         // Scan through the entire chain of panels and extract rows from each one

--- a/src/MatrixTeensy4Hub75Refresh_Impl.h
+++ b/src/MatrixTeensy4Hub75Refresh_Impl.h
@@ -656,7 +656,7 @@ FLASHMEM void SmartMatrixRefreshT4<refreshDepth, matrixWidth, matrixHeight, pane
 
     unsigned int minorLoopBytes, minorLoopIterations, majorLoopBytes, majorLoopIterations;
     int destinationAddressOffset, destinationAddressLastOffset, sourceAddressOffset, sourceAddressLastOffset, minorLoopOffset;
-    volatile uint32_t *destinationAddress1, *destinationAddress2, *sourceAddress;
+    volatile void *destinationAddress1, *destinationAddress2, *sourceAddress;
 
     rowBitStructBytesToShift = sizeof(SmartMatrixRefreshT4<refreshDepth, matrixWidth, matrixHeight, panelType, optionFlags>::matrixUpdateRows[0].rowbits[0].data);
 
@@ -677,11 +677,11 @@ FLASHMEM void SmartMatrixRefreshT4<refreshDepth, matrixWidth, matrixHeight, pane
     // The destination address is set to write to the OE duty cycle register, then the period register, then reset.
     minorLoopBytes = TIMER_REGISTERS_TO_UPDATE * sizeof(uint16_t);
     majorLoopIterations = 1;
-    sourceAddress = (volatile uint32_t*) & (matrixUpdateRows[0].rowbits[0].timerValues.timer_oe);
+    sourceAddress = & (matrixUpdateRows[0].rowbits[0].timerValues.timer_oe);
     sourceAddressOffset = sizeof(uint16_t); // address offset from timer_oe to timer_period
     sourceAddressLastOffset = -TIMER_REGISTERS_TO_UPDATE * sourceAddressOffset + sizeof(matrixUpdateRows[0].rowbits[0]);
-    destinationAddress1 = (volatile uint32_t*) timerRegisterOE;
-    destinationAddress2 = (volatile uint32_t*) timerRegisterPeriod;
+    destinationAddress1 = timerRegisterOE;
+    destinationAddress2 = timerRegisterPeriod;
     destinationAddressOffset = (int)destinationAddress2 - (int)destinationAddress1;
     destinationAddressLastOffset = -TIMER_REGISTERS_TO_UPDATE * destinationAddressOffset;
     dmaUpdateTimer.TCD->SADDR = sourceAddress;
@@ -717,7 +717,7 @@ FLASHMEM void SmartMatrixRefreshT4<refreshDepth, matrixWidth, matrixHeight, pane
     minorLoopBytes = minorLoopIterations * sizeof(uint32_t);
     majorLoopBytes = rowBitStructBytesToShift;
     majorLoopIterations = majorLoopBytes / minorLoopBytes;
-    sourceAddress = (uint32_t*) & (matrixUpdateRows[0].rowbits[0].data[0]);
+    sourceAddress = & (matrixUpdateRows[0].rowbits[0].data[0]);
     sourceAddressOffset = sizeof(uint32_t);
     sourceAddressLastOffset = sizeof(matrixUpdateRows[0].rowbits[0]) - majorLoopBytes; // at completion, move on to next bitplane
     destinationAddress1 = &(flexIO->SHIFTBUF[0]);


### PR DESCRIPTION
Fixing compiler warnings that appeared now that Teensyduino 1.58 has updated to GCC 11:
memcpy and memset throw warnings when used on RGB type objects - fixed this by casting to void *