### PR TITLE
Mono Color HUB12 Matrix Panel Drive Board ESP32 Support from Electrodragon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SmartMatrix Library
+# https://github.com/pixelmatix/SmartMatrix
+# 
+
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(SRCS
+                       INCLUDE_DIRS "src"
+                       REQUIRES driver arduino Adafruit-GFX-Library Adafruit_BusIO)
+
+project(SmartMatrix)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-idf_component_register(SRCS
+idf_component_register(SRC_DIRS "src"
                        INCLUDE_DIRS "src"
                        REQUIRES driver arduino Adafruit-GFX-Library Adafruit_BusIO)
 

--- a/src/MatrixEsp32Hub75Refresh_Impl.h
+++ b/src/MatrixEsp32Hub75Refresh_Impl.h
@@ -132,11 +132,11 @@ void SmartMatrixHub75Refresh<refreshDepth, matrixWidth, matrixHeight, panelType,
     matrixUpdateFrames[1] = (frameStruct *)heap_caps_malloc(sizeof(frameStruct), MALLOC_CAP_DMA);
     assert(matrixUpdateFrames[1] != NULL);
 
-    printf("sizeof framestruct: %08X\r\n", (uint32_t)sizeof(frameStruct));
+    printf("sizeof framestruct: %08" PRIX32 "\r\n", (uint32_t)sizeof(frameStruct));
     show_esp32_dma_mem("DMA Memory Available before ptr1 alloc");
-    printf("matrixUpdateFrames[0] pointer: %08X\r\n", (uint32_t)matrixUpdateFrames[0]);
+    printf("matrixUpdateFrames[0] pointer: %08" PRIX32 "\r\n", (uint32_t)matrixUpdateFrames[0]);
     show_esp32_dma_mem("DMA Memory Available before ptr2 alloc");
-    printf("matrixUpdateFrames[1] pointer: %08X\r\n", (uint32_t)matrixUpdateFrames[1]);
+    printf("matrixUpdateFrames[1] pointer: %08" PRIX32 "\r\n", (uint32_t)matrixUpdateFrames[1]);
 
     printf("Frame Structs Allocated from Heap:\r\n");
     show_esp32_all_mem();

--- a/src/MatrixEsp32Hub75Refresh_Impl.h
+++ b/src/MatrixEsp32Hub75Refresh_Impl.h
@@ -454,10 +454,10 @@ void SmartMatrixHub75Refresh<refreshDepth, matrixWidth, matrixHeight, panelType,
         .bits=MATRIX_I2S_MODE,
         .bufa=0,
         .bufb=0,
-        desccount,
-        desccount,
-        dmadesc_a,
-        dmadesc_b
+        .desccount_a=desccount,
+        .desccount_b=desccount,
+        .lldesc_a=dmadesc_a,
+		.lldesc_b=dmadesc_b
     };
 
     //Setup I2S

--- a/src/MatrixEsp32Hub75Refresh_NT_Impl.h
+++ b/src/MatrixEsp32Hub75Refresh_NT_Impl.h
@@ -446,10 +446,10 @@ void SmartMatrixHub75Refresh_NT<dummyvar>::begin(uint32_t dmaRamToKeepFreeBytes)
         .bits=MATRIX_I2S_MODE,
         .bufa=0,
         .bufb=0,
-        desccount,
-        desccount,
-        dmadesc_a,
-        dmadesc_b
+		.desccount_a=desccount,
+		.desccount_b=desccount,
+		.lldesc_a=dmadesc_a,
+		.lldesc_b=dmadesc_b
     };
 
     //Setup I2S

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -294,22 +294,11 @@
     15 16 Gnd
                         ESP32 pin / comment
     1	R0	23	Red Data (columns 1-16)
-    2	G0	15	Green Data (columns 1-16)
 
-    3	B0	4	Blue Data (columns 1-16)
     4	GND	GND	Ground
-
-    5	R1	16/RX2	Red Data (columns 17-32)
-    6	G1	27	Green Data (columns 17-32)
-
-    7	B1	17/TX2	Blue Data (columns 17-32)
-    8	E	12	Demux Input E for 64x64 panels
 
     9	A	19	Demux Input A0
     10	B	21	Demux Input A1
-
-    11	C	19	Demux Input A2
-    12	D	21	Demux Input E1, E3 (32x32 panels only)
 
     13	CLK	18	LED Drivers' Clock
     14	STB	2	LED Drivers' Latch
@@ -318,17 +307,17 @@
     16	GND	GND	Ground
     */
     #define R1_PIN  GPIO_NUM_23
-    #define G1_PIN  GPIO_NUM_15
-    #define B1_PIN  GPIO_NUM_4
-    #define R2_PIN  GPIO_NUM_16
-    #define G2_PIN  GPIO_NUM_27
-    #define B2_PIN  GPIO_NUM_17
+    #define G1_PIN  GPIO_NUM_NC
+    #define B1_PIN  GPIO_NUM_NC
+    #define R2_PIN  GPIO_NUM_NC
+    #define G2_PIN  GPIO_NUM_NC
+    #define B2_PIN  GPIO_NUM_NC
 
     #define A_PIN   GPIO_NUM_19
     #define B_PIN   GPIO_NUM_21
-    #define C_PIN   GPIO_NUM_19
-    #define D_PIN   GPIO_NUM_21
-    #define E_PIN   GPIO_NUM_12
+    #define C_PIN   GPIO_NUM_NC
+    #define D_PIN   GPIO_NUM_NC
+    #define E_PIN   GPIO_NUM_NC
     #define LAT_PIN GPIO_NUM_2
     #define OE_PIN  GPIO_NUM_22
 

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -305,8 +305,8 @@
     7	B1	17/TX2	Blue Data (columns 17-32)
     8	E	12	Demux Input E for 64x64 panels
 
-    9	A	5	Demux Input A0
-    10	B	18	Demux Input A1
+    9	A	19	Demux Input A0
+    10	B	21	Demux Input A1
 
     11	C	19	Demux Input A2
     12	D	21	Demux Input E1, E3 (32x32 panels only)
@@ -324,8 +324,8 @@
     #define G2_PIN  GPIO_NUM_27
     #define B2_PIN  GPIO_NUM_17
 
-    #define A_PIN   GPIO_NUM_5
-    #define B_PIN   GPIO_NUM_18
+    #define A_PIN   GPIO_NUM_19
+    #define B_PIN   GPIO_NUM_21
     #define C_PIN   GPIO_NUM_19
     #define D_PIN   GPIO_NUM_21
     #define E_PIN   GPIO_NUM_12

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -268,7 +268,13 @@
 
 #elif (GPIOPINOUT == ELECTRODRAGON_PINOUT)
 
-    #pragma message "MatrixHardware: ESP32 forum wiring"
+
+    // https://www.electrodragon.com/product/mono-color-hub12-matrix-panel-drive-board-esp32/
+    // https://w2.electrodragon.com/Board-dat/IDD/IDD1023-dat/IDD1023-dat.md
+    // https://github.com/Edragon/Arduino-ESP32/tree/master/libraries/DMD32-main
+    // https://github.com/Edragon/Arduino-ESP32/blob/master/libraries/DMD32-main/connection.png
+
+    #pragma message "MatrixHardware: Electrodragon Mono Color HUB12 Matrix Panel Drive Board ESP32 wiring"
 
     // ADDX is output directly using GPIO
     #define CLKS_DURING_LATCH   0

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -311,7 +311,7 @@
     11	C	19	Demux Input A2
     12	D	21	Demux Input E1, E3 (32x32 panels only)
 
-    13	CLK	22	LED Drivers' Clock
+    13	CLK	18	LED Drivers' Clock
     14	STB	26	LED Drivers' Latch
 
     15	OE	25	LED Drivers' Output Enable
@@ -332,7 +332,7 @@
     #define LAT_PIN GPIO_NUM_26
     #define OE_PIN  GPIO_NUM_25
 
-    #define CLK_PIN GPIO_NUM_22
+    #define CLK_PIN GPIO_NUM_18
 
 #elif (GPIOPINOUT == HUB75_ADAPTER_PINOUT)
 

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -445,11 +445,11 @@
     #define G2_PIN  GPIO_NUM_25
     #define B2_PIN  GPIO_NUM_0
 
-    #define A_PIN   -1
-    #define B_PIN   -1
-    #define C_PIN   -1
-    #define D_PIN   -1
-    #define E_PIN   -1
+    #define A_PIN   GPIO_NUM_NC
+    #define B_PIN   GPIO_NUM_NC
+    #define C_PIN   GPIO_NUM_NC
+    #define D_PIN   GPIO_NUM_NC
+    #define E_PIN   GPIO_NUM_NC
 
     #define LAT_PIN GPIO_NUM_27
     #define OE_PIN  GPIO_NUM_32
@@ -478,11 +478,11 @@
     #define G2_PIN  GPIO_NUM_25
     #define B2_PIN  GPIO_NUM_21
 
-    #define A_PIN   -1
-    #define B_PIN   -1
-    #define C_PIN   -1
-    #define D_PIN   -1
-    #define E_PIN   -1
+    #define A_PIN   GPIO_NUM_NC
+    #define B_PIN   GPIO_NUM_NC
+    #define C_PIN   GPIO_NUM_NC
+    #define D_PIN   GPIO_NUM_NC
+    #define E_PIN   GPIO_NUM_NC
 
     #define LAT_PIN GPIO_NUM_22
     #define OE_PIN  GPIO_NUM_19
@@ -511,11 +511,11 @@
     #define G2_PIN  GPIO_NUM_25
     #define B2_PIN  GPIO_NUM_21
 
-    #define A_PIN   -1
-    #define B_PIN   -1
-    #define C_PIN   -1
-    #define D_PIN   -1
-    #define E_PIN   -1
+    #define A_PIN   GPIO_NUM_NC
+    #define B_PIN   GPIO_NUM_NC
+    #define C_PIN   GPIO_NUM_NC
+    #define D_PIN   GPIO_NUM_NC
+    #define E_PIN   GPIO_NUM_NC
 
     #define LAT_PIN GPIO_NUM_22
     #define OE_PIN  GPIO_NUM_19
@@ -547,11 +547,11 @@
     #define G2_PIN  GPIO_NUM_25
     #define B2_PIN  GPIO_NUM_15
 
-    #define A_PIN   -1
-    #define B_PIN   -1
-    #define C_PIN   -1
-    #define D_PIN   -1
-    #define E_PIN   -1
+    #define A_PIN   GPIO_NUM_NC
+    #define B_PIN   GPIO_NUM_NC
+    #define C_PIN   GPIO_NUM_NC
+    #define D_PIN   GPIO_NUM_NC
+    #define E_PIN   GPIO_NUM_NC
 
     #define LAT_PIN GPIO_NUM_10
     #define OE_PIN  GPIO_NUM_9

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -293,7 +293,7 @@
     13 14 STB/Latch
     15 16 Gnd
                         ESP32 pin / comment
-    1	R0	2	Red Data (columns 1-16)
+    1	R0	23	Red Data (columns 1-16)
     2	G0	15	Green Data (columns 1-16)
 
     3	B0	4	Blue Data (columns 1-16)
@@ -317,7 +317,7 @@
     15	OE	25	LED Drivers' Output Enable
     16	GND	GND	Ground
     */
-    #define R1_PIN  GPIO_NUM_2
+    #define R1_PIN  GPIO_NUM_23
     #define G1_PIN  GPIO_NUM_15
     #define B1_PIN  GPIO_NUM_4
     #define R2_PIN  GPIO_NUM_16

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -312,7 +312,7 @@
     12	D	21	Demux Input E1, E3 (32x32 panels only)
 
     13	CLK	18	LED Drivers' Clock
-    14	STB	26	LED Drivers' Latch
+    14	STB	2	LED Drivers' Latch
 
     15	OE	22	LED Drivers' Output Enable
     16	GND	GND	Ground
@@ -329,7 +329,7 @@
     #define C_PIN   GPIO_NUM_19
     #define D_PIN   GPIO_NUM_21
     #define E_PIN   GPIO_NUM_12
-    #define LAT_PIN GPIO_NUM_26
+    #define LAT_PIN GPIO_NUM_2
     #define OE_PIN  GPIO_NUM_22
 
     #define CLK_PIN GPIO_NUM_18

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -39,9 +39,10 @@
 #define ESP32_JC_RIBBON_PINOUT_WEMOS    8
 #define HUB75_ADAPTER_LITE_V0_PINOUT    9
 #define ESP32_RGB64x32MatrixPanel_I2S_DMA_DEFAULT    10
+#define ELECTRODRAGON_PINOUT    11
 
 #ifndef GPIOPINOUT
-#define GPIOPINOUT ESP32_FORUM_PINOUT
+#define GPIOPINOUT ELECTRODRAGON_PINOUT
 #endif
 //#define GPIOPINOUT ESP32_FORUM_PINOUT_WITH_LATCH // note this mode is untested as of 2018-05-17 - not being used anymore now that SmartMatrix Shield is available
 //#define GPIOPINOUT SMARTLED_SHIELD_V0_PINOUT
@@ -248,6 +249,68 @@
     15	OE	25	LED Drivers' Output Enable
     16	GND	GND	Ground
     */ 
+    #define R1_PIN  GPIO_NUM_2
+    #define G1_PIN  GPIO_NUM_15
+    #define B1_PIN  GPIO_NUM_4
+    #define R2_PIN  GPIO_NUM_16
+    #define G2_PIN  GPIO_NUM_27
+    #define B2_PIN  GPIO_NUM_17
+
+    #define A_PIN   GPIO_NUM_5
+    #define B_PIN   GPIO_NUM_18
+    #define C_PIN   GPIO_NUM_19
+    #define D_PIN   GPIO_NUM_21
+    #define E_PIN   GPIO_NUM_12
+    #define LAT_PIN GPIO_NUM_26
+    #define OE_PIN  GPIO_NUM_25
+
+    #define CLK_PIN GPIO_NUM_22
+
+#elif (GPIOPINOUT == ELECTRODRAGON_PINOUT)
+
+    #pragma message "MatrixHardware: ESP32 forum wiring"
+
+    // ADDX is output directly using GPIO
+    #define CLKS_DURING_LATCH   0
+    #define MATRIX_I2S_MODE I2S_PARALLEL_BITS_16
+    #define MATRIX_DATA_STORAGE_TYPE uint16_t
+
+    /*
+    HUB 75
+    01 02 B0
+    03 04 Gnd
+    05 06 G1
+    07 08 E
+
+    09 10 B
+    11 12 D
+    13 14 STB/Latch
+    15 16 Gnd
+                        ESP32 pin / comment
+    1	R0	2	Red Data (columns 1-16)
+    2	G0	15	Green Data (columns 1-16)
+
+    3	B0	4	Blue Data (columns 1-16)
+    4	GND	GND	Ground
+
+    5	R1	16/RX2	Red Data (columns 17-32)
+    6	G1	27	Green Data (columns 17-32)
+
+    7	B1	17/TX2	Blue Data (columns 17-32)
+    8	E	12	Demux Input E for 64x64 panels
+
+    9	A	5	Demux Input A0
+    10	B	18	Demux Input A1
+
+    11	C	19	Demux Input A2
+    12	D	21	Demux Input E1, E3 (32x32 panels only)
+
+    13	CLK	22	LED Drivers' Clock
+    14	STB	26	LED Drivers' Latch
+
+    15	OE	25	LED Drivers' Output Enable
+    16	GND	GND	Ground
+    */
     #define R1_PIN  GPIO_NUM_2
     #define G1_PIN  GPIO_NUM_15
     #define B1_PIN  GPIO_NUM_4

--- a/src/MatrixHardware_ESP32_V0.h
+++ b/src/MatrixHardware_ESP32_V0.h
@@ -314,7 +314,7 @@
     13	CLK	18	LED Drivers' Clock
     14	STB	26	LED Drivers' Latch
 
-    15	OE	25	LED Drivers' Output Enable
+    15	OE	22	LED Drivers' Output Enable
     16	GND	GND	Ground
     */
     #define R1_PIN  GPIO_NUM_23
@@ -330,7 +330,7 @@
     #define D_PIN   GPIO_NUM_21
     #define E_PIN   GPIO_NUM_12
     #define LAT_PIN GPIO_NUM_26
-    #define OE_PIN  GPIO_NUM_25
+    #define OE_PIN  GPIO_NUM_22
 
     #define CLK_PIN GPIO_NUM_18
 

--- a/src/esp32_i2s_parallel.c
+++ b/src/esp32_i2s_parallel.c
@@ -26,11 +26,19 @@
 
 #include "soc/i2s_struct.h"
 #include "soc/i2s_reg.h"
+#include "soc/gpio_periph.h"
 #include "driver/periph_ctrl.h"
+#include "driver/gpio.h"
 #include "soc/io_mux_reg.h"
 #include "rom/lldesc.h"
 #include "esp_heap_caps.h"
 #include "esp32_i2s_parallel.h"
+
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/gpio.h"
+#else
+#error Target CONFIG_IDF_TARGET is not supported
+#endif
 
 typedef struct {
     volatile lldesc_t *dmadesc_a, *dmadesc_b;


### PR DESCRIPTION
https://www.electrodragon.com/product/mono-color-hub12-matrix-panel-drive-board-esp32/

Tested with a ARD LED 32X16 WT Arduino - LED-Matrix, 32 x 16 LEDs, weiß from reichelt elektronik GmbH

not yet well running on a ARD LED 32X16 RD Arduino - LED-Matrix, 32 x 16 LEDs, rot  from reichelt elektronik GmbH, may need to adopt some Timings. 